### PR TITLE
bug: fix workspace directory traversal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "layered-crate"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "layered-crate"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 description = "Tool to declare and verify internal dependencies amongst modules inside a crate"
 repository = "https://github.com/Pistonite/layered-crate"


### PR DESCRIPTION
When looking for a workspace, it was calling `parent()` on relative path, which can fail.

Canonicalize the path before traversing the parents